### PR TITLE
Fix package path for DefaultKryoInitializer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ the assigned class IDs are the same for senders and for receivers!
 How to customize kryo initialization
 ------------------------------------
 
-To further customize kryo you can extend the `io.altoo.pekko.serialization.kryo.DefaultKryoInitializer` and 
+To further customize kryo you can extend the `io.altoo.serialization.kryo.pekko.DefaultKryoInitializer` and 
 configure the FQCN under `pekko-kryo-serialization.kryo-initializer`.
 
 #### Configuring default field serializers


### PR DESCRIPTION
Corrected the package path for DefaultKryoInitializer in the documentation.

I downloaded v1.3.0 and found that the file contents had pekko dir late in the path not at the start.

```
     2747  01-01-2010 00:00   io/altoo/serialization/kryo/pekko/DefaultKryoInitializer.class
     5372  01-01-2010 00:00   io/altoo/serialization/kryo/pekko/PekkoKryoSerializer.class
     3819  01-01-2010 00:00   io/altoo/serialization/kryo/pekko/serializer/ActorRefSerializer.class
     4692  01-01-2010 00:00   io/altoo/serialization/kryo/pekko/serializer/ByteStringSerializer.class
```