### PR TITLE
fix lz4 cve by using the latest library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features
 * Does not require any additional build steps like compiling proto files, when using protobuf serialization
 * Almost any Scala and Java class can be serialized using it without any additional configuration or code changes
 * Efficient serialization of such Scala types like Option, Tuple, Enumeration, most of Scala's collection types
-* Greatly improves performance of Akka's remoting
+* Greatly improves performance of Pekko's remoting
 * Supports transparent AES encryption and different modes of compression
 * Apache 2.0 license
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,11 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
 // Basics
 
-// note: keep in sync to pekko https://github.com/apache/incubator-pekko/blob/main/project/Dependencies.scala
-val mainScalaVersion = "3.3.5"
-val secondaryScalaVersions = Seq("2.12.20", "2.13.16")
+// note: keep in sync to pekko https://github.com/apache/pekko/blob/main/project/Dependencies.scala
+val mainScalaVersion = "3.3.7"
+val secondaryScalaVersions = Seq("2.12.21", "2.13.18")
 
-val scalaKryoVersion = "1.3.0"
+val scalaKryoVersion = "1.3.1"
 val defaultPekkoVersion = "1.1.3"
 val pekkoVersion =
   System.getProperty("pekko.build.version", defaultPekkoVersion) match {


### PR DESCRIPTION
bump scala-kryo which replaces lz4 upstream dependency to fixed/maintained while using the same api

see #26 